### PR TITLE
Fix build errors in AST and parser

### DIFF
--- a/src/include/ast.h
+++ b/src/include/ast.h
@@ -34,15 +34,31 @@ struct ASTNode {
     }
 };
 
+class ASTExpression : public ASTNode {
+public:
+    std::vector<Token> tokens;
+
+    ASTExpression(std::vector<Token> tokens)
+        : ASTNode("Expression"), tokens(std::move(tokens)) {}
+
+    void print() const {
+        std::cout << "Expression: ";
+        for (const auto& token : tokens) {
+            std::cout << token.value << " ";
+        }
+        std::cout << std::endl;
+    }
+};
+
 class ASTAssign : public ASTNode {
 public:
     std::string lhs;
     ASTExpression rhs;
 
     ASTAssign(const std::string& lhs, const ASTExpression& rhs)
-        : ASTNode(ASTNodeType::Assignment), lhs(lhs), rhs(rhs) {}
+        : ASTNode("Assignment"), lhs(lhs), rhs(rhs) {}
 
-    void print() const override {
+    void print() const {
         std::cout << lhs << " = ";
         rhs.print();
     }
@@ -54,22 +70,6 @@ struct ASTModule : public ASTNode {
     std::vector<ASTAssign> assignments;  // Stores assignments
 
     ASTModule(std::string n) : ASTNode(), name(std::move(n)) {}
-};
-
-class ASTExpression : public ASTNode {
-public:
-    std::vector<Token> tokens;
-
-    ASTExpression(std::vector<Token> tokens)
-        : ASTNode(ASTNodeType::Expression), tokens(std::move(tokens)) {}
-
-    void print() const override {
-        std::cout << "Expression: ";
-        for (const auto& token : tokens) {
-            std::cout << token.value << " ";
-        }
-        std::cout << std::endl;
-    }
 };
 
 #endif // AST_H

--- a/src/include/parser.h
+++ b/src/include/parser.h
@@ -19,6 +19,7 @@ private:
     void expect(TokenType expectedType);  // ✅ Ensure this is declared
     ASTNode parsePort();     // ✅ Declare parsePort()
     ASTNode parseAssign();   // ✅ Declare parseAssign()
+    ASTExpression parseExpression();
 };
 
 #endif // PARSER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,7 +99,8 @@ int main() {
     }
 
     for (const auto& assign : module.assignments) {
-        std::cout << "Assignment: " << assign.lhs << " = " << assign.rhs << std::endl;
+        std::cout << "Assignment: " << assign.lhs << " = ";
+        assign.rhs.print();
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- define ASTExpression before ASTAssign
- remove unused ASTNodeType references
- declare `parseExpression` in parser header
- fix assignment printing in main

## Testing
- `cmake .`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6840a9754d80832aa94646aa813b4c9c