### PR TITLE
Enhance AST with additional SV constructs

### DIFF
--- a/src/include/ast.h
+++ b/src/include/ast.h
@@ -64,10 +64,45 @@ public:
     }
 };
 
+class ASTWire : public ASTNode {
+public:
+    explicit ASTWire(std::string n)
+        : ASTNode("Wire"), name(std::move(n)) {}
+    std::string name;
+};
+
+class ASTReg : public ASTNode {
+public:
+    explicit ASTReg(std::string n)
+        : ASTNode("Reg"), name(std::move(n)) {}
+    std::string name;
+};
+
+class ASTAlways : public ASTNode {
+public:
+    std::vector<std::string> sensitivityList;
+    std::vector<ASTNode> statements;
+
+    ASTAlways() : ASTNode("Always") {}
+};
+
+class ASTIf : public ASTNode {
+public:
+    ASTExpression condition;
+    std::vector<ASTNode> thenStmts;
+    std::vector<ASTNode> elseStmts;
+
+    explicit ASTIf(const ASTExpression& cond)
+        : ASTNode("If"), condition(cond) {}
+};
+
 struct ASTModule : public ASTNode {
     std::string name;
     std::vector<std::pair<TokenType, std::string>> ports;  // Stores (input/output, name)
     std::vector<ASTAssign> assignments;  // Stores assignments
+    std::vector<ASTWire> wires;
+    std::vector<ASTReg> regs;
+    std::vector<ASTAlways> alwaysBlocks;
 
     ASTModule(std::string n) : ASTNode(), name(std::move(n)) {}
 };

--- a/src/include/token.h
+++ b/src/include/token.h
@@ -6,6 +6,9 @@
 enum class TokenType {
     Module, EndModule,
     Input, Output,
+    Wire, Reg,
+    Always, Begin, End,
+    If, Else,
     LParen, RParen,
     Assign, Equal,
     Plus, Minus,

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -7,7 +7,7 @@
 
 std::vector<Token> lex(const std::string& code) {
     std::vector<Token> tokens;
-    std::regex tokenRegex(R"(\b(module|endmodule|input|output|assign)\b|[a-zA-Z_][a-zA-Z0-9_]*|[=;+*/()-]|,)");
+    std::regex tokenRegex(R"(\b(module|endmodule|input|output|assign|wire|reg|always|begin|end|if|else)\b|[a-zA-Z_][a-zA-Z0-9_]*|[=;+*/()-]|,)");
 
     std::sregex_iterator words_begin(code.begin(), code.end(), tokenRegex);
     std::sregex_iterator words_end;
@@ -20,6 +20,13 @@ std::vector<Token> lex(const std::string& code) {
         else if (value == "input") tokens.push_back({TokenType::Input, value});
         else if (value == "output") tokens.push_back({TokenType::Output, value});
         else if (value == "assign") tokens.push_back({TokenType::Assign, value});
+        else if (value == "wire") tokens.push_back({TokenType::Wire, value});
+        else if (value == "reg") tokens.push_back({TokenType::Reg, value});
+        else if (value == "always") tokens.push_back({TokenType::Always, value});
+        else if (value == "begin") tokens.push_back({TokenType::Begin, value});
+        else if (value == "end") tokens.push_back({TokenType::End, value});
+        else if (value == "if") tokens.push_back({TokenType::If, value});
+        else if (value == "else") tokens.push_back({TokenType::Else, value});
         else if (value == "=") tokens.push_back({TokenType::Equal, value});
         else if (value == "+") tokens.push_back({TokenType::Plus, value});
         else if (value == "-") tokens.push_back({TokenType::Minus, value});

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -11,6 +11,13 @@ std::string tokenTypeToString(TokenType type) {
         case TokenType::Minus: return "Minus";
         case TokenType::Input: return "Input";
         case TokenType::Output: return "Output";
+        case TokenType::Wire: return "Wire";
+        case TokenType::Reg: return "Reg";
+        case TokenType::Always: return "Always";
+        case TokenType::Begin: return "Begin";
+        case TokenType::End: return "End";
+        case TokenType::If: return "If";
+        case TokenType::Else: return "Else";
         case TokenType::Assign: return "Assign";
         case TokenType::Number: return "Number";
         case TokenType::Semicolon: return "Semicolon";


### PR DESCRIPTION
## Summary
- expand `TokenType` with common SystemVerilog keywords
- extend lexer to recognize the new tokens
- add AST node classes for `wire`, `reg`, `always`, and `if`
- store wires, regs and always blocks on `ASTModule`

## Testing
- `cmake .`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6840ab6aa440832a81ad28edf7231d3b